### PR TITLE
Fix deprecation warnings in newer Python versions due to invalid escape sequences

### DIFF
--- a/sqe_fitting/circle_fitter.py
+++ b/sqe_fitting/circle_fitter.py
@@ -9,7 +9,7 @@ Ref:
 """
 
 def moment_matrix(x: np.ndarray, y: np.ndarray):
-    """Return the matrix of the moments
+    r"""Return the matrix of the moments
     
     The matrix of the moments is defined as
     [[Mzz, Mxz, Myz, Mz],

--- a/sqe_fitting/signal_util.py
+++ b/sqe_fitting/signal_util.py
@@ -114,7 +114,7 @@ def find_peaks(data, x=1., height=None, distance=None, prominence=None, width=No
     Args:
         data (np.ndarray): Data with peaks
         x (np.ndarray): x-axis of data
-        height (float): Threshold of height normalized baseline noise (e.g. height=10 means that peak larger than 10\sigma from baseline would be detected)
+        height (float): Threshold of height normalized baseline noise (e.g. height=10 means that peak larger than 10 sigma from baseline would be detected)
         distance (float): Minimum distance between the peaks, distance in the same unit of frequency
         prominence (float): Prominence normalized by normalized by baseline_noise
         width: Peak width


### PR DESCRIPTION
Found with
```
ruff check --select W605
```